### PR TITLE
REDIS_PORT env variable fixed

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - REDIS_PORT=8000
+      # - REDIS_PORT=8000
       - REDIS_HOST=redis  # Set Redis hostname
     depends_on:
       redis:


### PR DESCRIPTION
docker compose had different redis port set as env variable, it is removed now